### PR TITLE
LOD generator presets

### DIFF
--- a/Editor/LODGeneratorPresetEditor.cs
+++ b/Editor/LODGeneratorPresetEditor.cs
@@ -1,0 +1,235 @@
+﻿#region License
+/*
+MIT License
+
+Copyright(c) 2017-2020 Mattias Edlund
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using UnityEditor;
+using UnityEditor.SceneManagement;
+
+namespace UnityMeshSimplifier.Editor
+{
+    [CustomEditor(typeof(LODGeneratorPreset))]
+    internal sealed class LODGeneratorPresetEditor : UnityEditor.Editor
+    {
+        private const string FadeModeFieldName = "fadeMode";
+        private const string AnimateCrossFadingFieldName = "animateCrossFading";
+        private const string SimplificationOptionsFieldName = "simplificationOptions";
+        private const string LevelsFieldName = "levels";
+        private const string LevelScreenRelativeHeightFieldName = "screenRelativeTransitionHeight";
+        private const string LevelFadeTransitionWidthFieldName = "fadeTransitionWidth";
+        private const string LevelQualityFieldName = "quality";
+        private const string LevelCombineMeshesFieldName = "combineMeshes";
+        private const string LevelCombineSubMeshesFieldName = "combineSubMeshes";
+        private const string LevelRenderersFieldName = "renderers";
+        private const string SimplificationOptionsEnableSmartLinkFieldName = "EnableSmartLink";
+        private const string SimplificationOptionsVertexLinkDistanceFieldName = "VertexLinkDistance";
+        private const float RemoveLevelButtonSize = 20f;
+
+        private SerializedProperty fadeModeProperty = null;
+        private SerializedProperty animateCrossFadingProperty = null;
+        private SerializedProperty simplificationOptionsProperty = null;
+        private SerializedProperty levelsProperty = null;
+
+        private bool[] settingsExpanded = null;
+        private LODGeneratorPreset lodGeneratorPreset = null;
+
+        private static readonly GUIContent createLevelButtonContent = new GUIContent("Create Level", "Creates a new LOD level.");
+        private static readonly GUIContent deleteLevelButtonContent = new GUIContent("X", "Deletes this LOD level.");
+        private static readonly GUIContent settingsContent = new GUIContent("Settings", "The settings for the LOD level.");
+        private static readonly Color removeColor = new Color(1f, 0.6f, 0.6f, 1f);
+
+        private void OnEnable()
+        {
+            fadeModeProperty = serializedObject.FindProperty(FadeModeFieldName);
+            animateCrossFadingProperty = serializedObject.FindProperty(AnimateCrossFadingFieldName);
+            simplificationOptionsProperty = serializedObject.FindProperty(SimplificationOptionsFieldName);
+            levelsProperty = serializedObject.FindProperty(LevelsFieldName);
+
+            lodGeneratorPreset = target as LODGeneratorPreset;
+        }
+
+        public override void OnInspectorGUI()
+        {
+            serializedObject.UpdateIfRequiredOrScript();
+
+            DrawView();
+
+            serializedObject.ApplyModifiedProperties();
+        }
+
+        private void DrawView()
+        {
+            EditorGUILayout.PropertyField(fadeModeProperty);
+            var fadeMode = (LODFadeMode)fadeModeProperty.intValue;
+
+            bool hasCrossFade = (fadeMode == LODFadeMode.CrossFade || fadeMode == LODFadeMode.SpeedTree);
+            if (hasCrossFade)
+            {
+                EditorGUILayout.PropertyField(animateCrossFadingProperty);
+            }
+
+            DrawSimplificationOptions();
+
+            if (settingsExpanded == null || settingsExpanded.Length != levelsProperty.arraySize)
+            {
+                var newSettingsExpanded = new bool[levelsProperty.arraySize];
+                if (settingsExpanded != null)
+                {
+                    System.Array.Copy(settingsExpanded, 0, newSettingsExpanded, 0, Mathf.Min(settingsExpanded.Length, newSettingsExpanded.Length));
+                }
+                settingsExpanded = newSettingsExpanded;
+            }
+
+            for (int levelIndex = 0; levelIndex < levelsProperty.arraySize; levelIndex++)
+            {
+                var levelProperty = levelsProperty.GetArrayElementAtIndex(levelIndex);
+                DrawLevel(levelIndex, levelProperty, hasCrossFade);
+            }
+
+            if (GUILayout.Button(createLevelButtonContent))
+            {
+                CreateLevel();
+            }
+        }
+
+        private void DrawSimplificationOptions()
+        {
+            if (EditorGUILayout.PropertyField(simplificationOptionsProperty, false))
+            {
+                ++EditorGUI.indentLevel;
+
+                var enableSmartLinkProperty = simplificationOptionsProperty.FindPropertyRelative(SimplificationOptionsEnableSmartLinkFieldName);
+
+                var childProperties = simplificationOptionsProperty.GetChildProperties();
+                foreach (var childProperty in childProperties)
+                {
+                    if (!enableSmartLinkProperty.boolValue && string.Equals(childProperty.name, SimplificationOptionsVertexLinkDistanceFieldName))
+                        continue;
+
+                    EditorGUILayout.PropertyField(childProperty, true);
+                }
+
+                --EditorGUI.indentLevel;
+            }
+        }
+
+        private void DrawLevel(int index, SerializedProperty levelProperty, bool hasCrossFade)
+        {
+            EditorGUILayout.BeginVertical(EditorStyles.helpBox);
+            EditorGUILayout.BeginHorizontal(EditorStyles.helpBox);
+            GUILayout.Label(string.Format("Level {0}", index + 1), EditorStyles.boldLabel);
+
+            var previousBackgroundColor = GUI.backgroundColor;
+            GUI.backgroundColor = removeColor;
+            if (GUILayout.Button(deleteLevelButtonContent, GUILayout.Width(RemoveLevelButtonSize)))
+            {
+                DeleteLevel(index);
+            }
+            GUI.backgroundColor = previousBackgroundColor;
+            EditorGUILayout.EndHorizontal();
+
+            ++EditorGUI.indentLevel;
+
+            var screenRelativeHeightProperty = levelProperty.FindPropertyRelative(LevelScreenRelativeHeightFieldName);
+            EditorGUILayout.PropertyField(screenRelativeHeightProperty);
+
+            var qualityProperty = levelProperty.FindPropertyRelative(LevelQualityFieldName);
+            EditorGUILayout.PropertyField(qualityProperty);
+
+            bool animateCrossFading = (hasCrossFade ? animateCrossFadingProperty.boolValue : false);
+            settingsExpanded[index] = EditorGUILayout.Foldout(settingsExpanded[index], settingsContent);
+            if (settingsExpanded[index])
+            {
+                ++EditorGUI.indentLevel;
+
+                var combineMeshesProperty = levelProperty.FindPropertyRelative(LevelCombineMeshesFieldName);
+                EditorGUILayout.PropertyField(combineMeshesProperty);
+
+                if (combineMeshesProperty.boolValue)
+                {
+                    var combineSubMeshesProperty = levelProperty.FindPropertyRelative(LevelCombineSubMeshesFieldName);
+                    EditorGUILayout.PropertyField(combineSubMeshesProperty);
+                }
+
+                var childProperties = levelProperty.GetChildProperties();
+                foreach (var childProperty in childProperties)
+                {
+                    if (string.Equals(childProperty.name, LevelScreenRelativeHeightFieldName) || string.Equals(childProperty.name, LevelQualityFieldName) ||
+                        string.Equals(childProperty.name, LevelCombineMeshesFieldName) || string.Equals(childProperty.name, LevelCombineSubMeshesFieldName) ||
+                        string.Equals(childProperty.name, LevelRenderersFieldName))
+                    {
+                        continue;
+                    }
+                    else if ((!hasCrossFade || !animateCrossFading) && string.Equals(childProperty.name, LevelFadeTransitionWidthFieldName))
+                    {
+                        continue;
+                    }
+
+                    EditorGUILayout.PropertyField(childProperty, true);
+                }
+
+                --EditorGUI.indentLevel;
+            }
+
+            --EditorGUI.indentLevel;
+            EditorGUILayout.EndVertical();
+        }
+
+        private void CreateLevel()
+        {
+            int newIndex = levelsProperty.arraySize;
+            levelsProperty.InsertArrayElementAtIndex(newIndex);
+            var newLevelProperty = levelsProperty.GetArrayElementAtIndex(newIndex);
+            var lastLevelProperty = (newIndex > 0 ? levelsProperty.GetArrayElementAtIndex(newIndex - 1) : null);
+            var newScreenRelativeHeightProperty = newLevelProperty.FindPropertyRelative(LevelScreenRelativeHeightFieldName);
+            var newQualityProperty = newLevelProperty.FindPropertyRelative(LevelQualityFieldName);
+
+            if (lastLevelProperty != null)
+            {
+                var lastScreenRelativeHeightProperty = lastLevelProperty.FindPropertyRelative(LevelScreenRelativeHeightFieldName);
+                var lastQualityProperty = lastLevelProperty.FindPropertyRelative(LevelQualityFieldName);
+                newScreenRelativeHeightProperty.floatValue = lastScreenRelativeHeightProperty.floatValue * 0.5f;
+                newQualityProperty.floatValue = lastQualityProperty.floatValue * 0.65f;
+            }
+            else
+            {
+                newScreenRelativeHeightProperty.floatValue = 0.6f;
+                newQualityProperty.floatValue = 1f;
+            }
+
+            serializedObject.ApplyModifiedProperties();
+            GUIUtility.ExitGUI();
+        }
+
+        private void DeleteLevel(int index)
+        {
+            levelsProperty.DeleteArrayElementAtIndex(index);
+            serializedObject.ApplyModifiedProperties();
+            GUIUtility.ExitGUI();
+        }
+    }
+}

--- a/Editor/LODGeneratorPresetEditor.cs.meta
+++ b/Editor/LODGeneratorPresetEditor.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: ba0c107493a0497aa0f6f0fc37b308da
+timeCreated: 1658437406

--- a/Runtime/Components/LODGeneratorHelper.cs
+++ b/Runtime/Components/LODGeneratorHelper.cs
@@ -25,6 +25,7 @@ SOFTWARE.
 #endregion
 
 using UnityEngine;
+using System.Linq;
 
 namespace UnityMeshSimplifier
 {
@@ -35,19 +36,26 @@ namespace UnityMeshSimplifier
     public sealed class LODGeneratorHelper : MonoBehaviour
     {
         #region Fields
-        [SerializeField, Tooltip("The fade mode used by the created LOD group.")]
-        private LODFadeMode fadeMode = LODFadeMode.None;
-        [SerializeField, Tooltip("If the cross-fading should be animated by time.")]
-        private bool animateCrossFading = false;
-
         [SerializeField, Tooltip("If the renderers under this game object and any children should be automatically collected.")]
         private bool autoCollectRenderers = true;
 
-        [SerializeField, Tooltip("The simplification options.")]
-        private SimplificationOptions simplificationOptions = SimplificationOptions.Default;
-
         [SerializeField, Tooltip("The path within the assets directory to save the generated assets. Leave this empty to use the default path.")]
         private string saveAssetsPath = string.Empty;
+
+        [SerializeField, Tooltip("The LOD Generator preset to use.")]
+        private LODGeneratorPreset lodGeneratorPreset = null;
+
+        [SerializeField, Tooltip("Whether to enable customization of preset-derived generation settings.")]
+        private bool customizeSettings = true;
+
+        [SerializeField, Tooltip("The fade mode used by the created LOD group.")]
+        private LODFadeMode fadeMode = LODFadeMode.None;
+
+        [SerializeField, Tooltip("If the cross-fading should be animated by time.")]
+        private bool animateCrossFading = false;
+
+        [SerializeField, Tooltip("The simplification options.")]
+        private SimplificationOptions simplificationOptions = SimplificationOptions.Default;
 
         [SerializeField, Tooltip("The LOD levels.")]
         private LODLevel[] levels = null;
@@ -58,40 +66,12 @@ namespace UnityMeshSimplifier
 
         #region Properties
         /// <summary>
-        /// Gets or sets the fade mode used by the created LOD group.
-        /// </summary>
-        public LODFadeMode FadeMode
-        {
-            get { return fadeMode; }
-            set { fadeMode = value; }
-        }
-
-        /// <summary>
-        /// Gets or sets if the cross-fading should be animated by time. The animation duration
-        /// is specified globally as crossFadeAnimationDuration.
-        /// </summary>
-        public bool AnimateCrossFading
-        {
-            get { return animateCrossFading; }
-            set { animateCrossFading = value; }
-        }
-
-        /// <summary>
         /// Gets or sets if the renderers under this game object and any children should be automatically collected.
         /// </summary>
         public bool AutoCollectRenderers
         {
             get { return autoCollectRenderers; }
             set { autoCollectRenderers = value; }
-        }
-
-        /// <summary>
-        /// Gets or sets the simplification options.
-        /// </summary>
-        public SimplificationOptions SimplificationOptions
-        {
-            get { return simplificationOptions; }
-            set { simplificationOptions = value; }
         }
 
         /// <summary>
@@ -105,12 +85,98 @@ namespace UnityMeshSimplifier
         }
 
         /// <summary>
+        /// Gets or sets a LOD generator preset. Presets can be used to drive simplification options and levels in a sharable way.
+        /// </summary>
+        public LODGeneratorPreset LodGeneratorPreset
+        {
+            get { return lodGeneratorPreset; }
+            set { lodGeneratorPreset = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets if the simplification options and levels should be customizable, versus driven by the specified preset.
+        /// </summary>
+        public bool CustomizeSettings
+        {
+            get { return customizeSettings; }
+            set { customizeSettings = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the fade mode used by the created LOD group.
+        /// </summary>
+        public LODFadeMode FadeMode
+        {
+            get { return fadeMode; }
+            set
+            {
+                if (!customizeSettings)
+                {
+                    fadeMode = value;
+                }
+                else
+                {
+                    WarnDisabledCustomization();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets if the cross-fading should be animated by time. The animation duration
+        /// is specified globally as crossFadeAnimationDuration.
+        /// </summary>
+        public bool AnimateCrossFading
+        {
+            get { return animateCrossFading; }
+            set
+            {
+                if (!customizeSettings)
+                {
+                    animateCrossFading = value;
+                }
+                else
+                {
+                    WarnDisabledCustomization();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the simplification options.
+        /// </summary>
+        public SimplificationOptions SimplificationOptions
+        {
+            get { return simplificationOptions; }
+            set
+            {
+                if (!customizeSettings)
+                {
+                    simplificationOptions = value;
+                }
+                else
+                {
+                    WarnDisabledCustomization();
+                }
+            }
+        }
+
+        /// <summary>
         /// Gets or sets the LOD levels for this generator.
         /// </summary>
         public LODLevel[] Levels
         {
             get { return levels; }
-            set { levels = value; }
+            set
+            {
+                if (!customizeSettings)
+                {
+                    levels = value;
+                }
+                else
+                {
+                    WarnDisabledCustomization();
+                }
+            }
         }
 
         /// <summary>
@@ -125,48 +191,67 @@ namespace UnityMeshSimplifier
         #region Unity Events
         private void Reset()
         {
-            fadeMode = LODFadeMode.None;
-            animateCrossFading = false;
             autoCollectRenderers = true;
-            simplificationOptions = SimplificationOptions.Default;
+            ResetPresetDerivedSettings();
+        }
 
-            levels = new LODLevel[]
+        private void OnValidate()
+        {
+            if (!customizeSettings)
             {
-                new LODLevel(0.5f, 1f)
-                {
-                    CombineMeshes = false,
-                    CombineSubMeshes = false,
-                    SkinQuality = SkinQuality.Auto,
-                    ShadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.On,
-                    ReceiveShadows = true,
-                    SkinnedMotionVectors = true,
-                    LightProbeUsage = UnityEngine.Rendering.LightProbeUsage.BlendProbes,
-                    ReflectionProbeUsage = UnityEngine.Rendering.ReflectionProbeUsage.BlendProbes,
-                },
-                new LODLevel(0.17f, 0.65f)
-                {
-                    CombineMeshes = true,
-                    CombineSubMeshes = false,
-                    SkinQuality = SkinQuality.Auto,
-                    ShadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.On,
-                    ReceiveShadows = true,
-                    SkinnedMotionVectors = true,
-                    LightProbeUsage = UnityEngine.Rendering.LightProbeUsage.BlendProbes,
-                    ReflectionProbeUsage = UnityEngine.Rendering.ReflectionProbeUsage.Simple
-                },
-                new LODLevel(0.02f, 0.4225f)
-                {
-                    CombineMeshes = true,
-                    CombineSubMeshes = true,
-                    SkinQuality = SkinQuality.Bone2,
-                    ShadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off,
-                    ReceiveShadows = false,
-                    SkinnedMotionVectors = false,
-                    LightProbeUsage = UnityEngine.Rendering.LightProbeUsage.Off,
-                    ReflectionProbeUsage = UnityEngine.Rendering.ReflectionProbeUsage.Off
-                }
-            };
+                UpdateSettingsFromPreset();
+            }
         }
         #endregion
+
+        private void WarnDisabledCustomization()
+        {
+            Debug.LogWarning($"Attempted to set a preset-driven property on a {typeof(LODGeneratorHelper)} while customization is disabled. Enable customization first.");
+        }
+
+        private void ResetPresetDerivedSettings()
+        {
+            fadeMode = LODFadeMode.None;
+            animateCrossFading = false;
+            simplificationOptions = SimplificationOptions.Default;
+            levels = LODLevel.GetDefaultLevels();
+        }
+
+        private void UpdateSettingsFromPreset()
+        {
+            // Retain copy of levels so any specified renderers can survive reset
+            LODLevel[] previousLevels = (LODLevel[])levels.Clone();
+
+            // Copy settings from preset, or use defaults if no preset specified
+            if (lodGeneratorPreset != null)
+            {
+                fadeMode = lodGeneratorPreset.FadeMode;
+                animateCrossFading = lodGeneratorPreset.AnimateCrossFading;
+                simplificationOptions = lodGeneratorPreset.SimplificationOptions;
+                levels = (LODLevel[])lodGeneratorPreset.Levels.Clone();
+            }
+            else
+            {
+                ResetPresetDerivedSettings();
+            }
+
+            // Copy specified renderers over
+            int rendererCopyCount = Mathf.Min(levels.Length, previousLevels.Length);
+            for(int idx = 0; idx < rendererCopyCount; idx++)
+            {
+                levels[idx].Renderers = (Renderer[])previousLevels[idx].Renderers.Clone();
+            }
+        }
+
+        /// <summary>
+        /// Gets whether preset-derived settings match the preset (a mismatch is possible if the preset asset is modified and settings aren't updated)
+        /// </summary>
+        public bool SettingsMatchPreset()
+        {
+            return fadeMode == lodGeneratorPreset.FadeMode &&
+                animateCrossFading == lodGeneratorPreset.AnimateCrossFading &&
+                simplificationOptions.Equals(lodGeneratorPreset.SimplificationOptions) &&
+                levels.SequenceEqual(lodGeneratorPreset.Levels);
+        }
     }
 }

--- a/Runtime/LODGeneratorPreset.cs
+++ b/Runtime/LODGeneratorPreset.cs
@@ -1,0 +1,97 @@
+﻿#region License
+/*
+MIT License
+
+Copyright(c) 2017-2020 Mattias Edlund
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+#endregion
+
+using UnityEngine;
+
+namespace UnityMeshSimplifier
+{
+    [CreateAssetMenu(
+        fileName = "LOD Preset",
+        menuName = "Mesh Simplifier/LOD Preset")]
+    public sealed class LODGeneratorPreset : ScriptableObject
+    {
+        [SerializeField, Tooltip("The fade mode used by the created LOD group.")]
+        private LODFadeMode fadeMode = LODFadeMode.None;
+
+        [SerializeField, Tooltip("If the cross-fading should be animated by time.")]
+        private bool animateCrossFading = false;
+
+        [SerializeField, Tooltip("The simplification options.")]
+        private SimplificationOptions simplificationOptions = SimplificationOptions.Default;
+
+        [SerializeField, Tooltip("The LOD levels.")]
+        private LODLevel[] levels = null;
+
+        #region Properties
+        /// <summary>
+        /// Gets or sets the fade mode used by the created LOD group.
+        /// </summary>
+        public LODFadeMode FadeMode
+        {
+            get { return fadeMode; }
+            set { fadeMode = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets if the cross-fading should be animated by time. The animation duration
+        /// is specified globally as crossFadeAnimationDuration.
+        /// </summary>
+        public bool AnimateCrossFading
+        {
+            get { return animateCrossFading; }
+            set { animateCrossFading = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the simplification options.
+        /// </summary>
+        public SimplificationOptions SimplificationOptions
+        {
+            get { return simplificationOptions; }
+            set { simplificationOptions = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the LOD levels for this generator.
+        /// </summary>
+        public LODLevel[] Levels
+        {
+            get { return levels; }
+            set { levels = value; }
+        }
+        #endregion
+
+        #region Unity Events
+        private void Reset()
+        {
+            fadeMode = LODFadeMode.None;
+            animateCrossFading = false;
+            simplificationOptions = SimplificationOptions.Default;
+            levels = LODLevel.GetDefaultLevels();
+        }
+        #endregion
+    }
+}

--- a/Runtime/LODGeneratorPreset.cs.meta
+++ b/Runtime/LODGeneratorPreset.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: dfe269aae04c466699460584399ceb56
+timeCreated: 1658438456

--- a/Runtime/LODLevel.cs
+++ b/Runtime/LODLevel.cs
@@ -34,7 +34,7 @@ namespace UnityMeshSimplifier
     /// A LOD (level of detail) level.
     /// </summary>
     [Serializable]
-    public struct LODLevel
+    public struct LODLevel : IEquatable<LODLevel>
     {
         #region Fields
         [SerializeField, Range(0f, 1f), Tooltip("The screen relative height to use for the transition.")]
@@ -242,5 +242,84 @@ namespace UnityMeshSimplifier
             this.reflectionProbeUsage = ReflectionProbeUsage.BlendProbes;
         }
         #endregion
+
+        #region IEquatable implementation
+        public bool Equals(LODLevel other)
+        {
+            return screenRelativeTransitionHeight == other.screenRelativeTransitionHeight &&
+                fadeTransitionWidth == other.fadeTransitionWidth &&
+                quality == other.quality &&
+                combineMeshes == other.combineMeshes &&
+                combineSubMeshes == other.combineSubMeshes &&
+                skinQuality == other.skinQuality &&
+                shadowCastingMode == other.shadowCastingMode &&
+                receiveShadows == other.receiveShadows &&
+                motionVectorGenerationMode == other.motionVectorGenerationMode &&
+                skinnedMotionVectors == other.skinnedMotionVectors &&
+                lightProbeUsage == other.lightProbeUsage &&
+                reflectionProbeUsage == other.reflectionProbeUsage;
+        }
+        public override bool Equals(object obj) => obj is LODLevel other && Equals(other);
+        public override int GetHashCode()
+        {
+            return (screenRelativeTransitionHeight,
+                fadeTransitionWidth,
+                quality,
+                combineMeshes,
+                combineSubMeshes,
+                skinQuality,
+                shadowCastingMode,
+                receiveShadows,
+                motionVectorGenerationMode,
+                skinnedMotionVectors,
+                lightProbeUsage,
+                reflectionProbeUsage).GetHashCode();
+        }
+        #endregion
+
+        /// <summary>
+        /// Gets default LOD levels.
+        /// </summary>
+        /// <returns>Default LOD levels.</returns>
+        public static LODLevel[] GetDefaultLevels()
+        {
+            // TODO: Expose default levels as a project setting, rather than hard-coding values.
+            return new LODLevel[]
+            {
+                new LODLevel(0.5f, 1f)
+                {
+                    CombineMeshes = false,
+                    CombineSubMeshes = false,
+                    SkinQuality = SkinQuality.Auto,
+                    ShadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.On,
+                    ReceiveShadows = true,
+                    SkinnedMotionVectors = true,
+                    LightProbeUsage = UnityEngine.Rendering.LightProbeUsage.BlendProbes,
+                    ReflectionProbeUsage = UnityEngine.Rendering.ReflectionProbeUsage.BlendProbes,
+                },
+                new LODLevel(0.17f, 0.65f)
+                {
+                    CombineMeshes = true,
+                    CombineSubMeshes = false,
+                    SkinQuality = SkinQuality.Auto,
+                    ShadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.On,
+                    ReceiveShadows = true,
+                    SkinnedMotionVectors = true,
+                    LightProbeUsage = UnityEngine.Rendering.LightProbeUsage.BlendProbes,
+                    ReflectionProbeUsage = UnityEngine.Rendering.ReflectionProbeUsage.Simple
+                },
+                new LODLevel(0.02f, 0.4225f)
+                {
+                    CombineMeshes = true,
+                    CombineSubMeshes = true,
+                    SkinQuality = SkinQuality.Bone2,
+                    ShadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off,
+                    ReceiveShadows = false,
+                    SkinnedMotionVectors = false,
+                    LightProbeUsage = UnityEngine.Rendering.LightProbeUsage.Off,
+                    ReflectionProbeUsage = UnityEngine.Rendering.ReflectionProbeUsage.Off
+                }
+            };
+        }
     }
 }

--- a/Runtime/SimplificationOptions.cs
+++ b/Runtime/SimplificationOptions.cs
@@ -35,7 +35,7 @@ namespace UnityMeshSimplifier
     /// </summary>
     [Serializable]
     [StructLayout(LayoutKind.Auto)]
-    public struct SimplificationOptions
+    public struct SimplificationOptions  : IEquatable<SimplificationOptions>
     {
         /// <summary>
         /// The default simplification options.
@@ -118,5 +118,35 @@ namespace UnityMeshSimplifier
         /// </summary>
         [Range(0, 4), Tooltip("The UV component count. The same UV component count will be used on all UV channels.")]
         public int UVComponentCount;
+
+        #region IEquatable implementation
+        public bool Equals(SimplificationOptions other)
+        {
+            return PreserveBorderEdges == other.PreserveBorderEdges &&
+                PreserveUVSeamEdges == other.PreserveUVSeamEdges &&
+                PreserveUVFoldoverEdges == other.PreserveUVFoldoverEdges &&
+                PreserveSurfaceCurvature == other.PreserveSurfaceCurvature &&
+                EnableSmartLink == other.EnableSmartLink &&
+                VertexLinkDistance == other.VertexLinkDistance &&
+                MaxIterationCount == other.MaxIterationCount &&
+                Agressiveness == other.Agressiveness &&
+                ManualUVComponentCount == other.ManualUVComponentCount &&
+                UVComponentCount == other.UVComponentCount;
+        }
+        public override bool Equals(object obj) => obj is SimplificationOptions other && Equals(other);
+        public override int GetHashCode()
+        {
+            return (PreserveBorderEdges,
+                PreserveUVSeamEdges,
+                PreserveUVFoldoverEdges,
+                PreserveSurfaceCurvature,
+                EnableSmartLink,
+                VertexLinkDistance,
+                MaxIterationCount,
+                Agressiveness,
+                ManualUVComponentCount,
+                UVComponentCount).GetHashCode();
+        }
+        #endregion
     }
 }


### PR DESCRIPTION
- Added `LODGeneratorPreset`, a `ScriptableObject` type containing sharable LOD settings.
- Modified `LODGeneratorHelper` to use `LODGeneratorPreset`. When a preset is specified on a helper, that helper's LOD generation settings will be updated to match the preset. Customization can be enabled on a helper to tweak loaded settings, or disabled to revert the helper's settings to the preset.
- Modified `LODGeneratorHelperEditor` to disable (but still display) preset-driven settings unless customization is enabled.
- Implemented `IEquatable` on `LODLevel` and `SimplificationOptions` , necessary to support future validation & auto-propagation of preset changes to assets referencing that preset.